### PR TITLE
arm: dts: kakip: Fix PHY address for ethernet0

### DIFF
--- a/arch/arm/dts/kakip-es1.dts
+++ b/arch/arm/dts/kakip-es1.dts
@@ -130,9 +130,9 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		phy0: ethernet-phy@0 {
+		phy0: ethernet-phy@3 {
 			compatible = "ethernet-phy-ieee802.3-c22";
-			reg = <0>;
+			reg = <3>;
 		};
 	};
 };


### PR DESCRIPTION
The PHY address for ethernet0 is 3, not 0.
This fixes to the correct PHY address.